### PR TITLE
enable use of ’sbt publish local’

### DIFF
--- a/src/main/scala/fr/fpe/scalatest/jgiven/SbtJgivenScalatestReporterPlugin.scala
+++ b/src/main/scala/fr/fpe/scalatest/jgiven/SbtJgivenScalatestReporterPlugin.scala
@@ -10,7 +10,7 @@ object SbtJgivenScalatestReporterPlugin extends AutoPlugin {
   override lazy val projectSettings = Seq(
     testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-C", classOf[JGivenHtml5Reporter].getName),
     libraryDependencies += Defaults
-      .sbtPluginExtra("name.lemerdy.sebastian" % "sbt-jgiven-scalatest-reporter" % "0.1-SNAPSHOT", "1.0", "2.12") % Test
+      .sbtPluginExtra("fr.fpe" % "sbt-jgiven-scalatest-reporter" % "0.1-SNAPSHOT", "1.0", "2.12") % Test
   )
 
   override lazy val buildSettings = Seq()


### PR DESCRIPTION
I could not find the public repo for the plugin, so as mitigation I’m using an sbt ’publish local’

I assume you want to align the naming in sbt plugin config and sbtPluginExtra in SbtJgivenScalatestReporterPlugin.scala:13, otherwise you get an sbt error.
```
addSbtPlugin("fr.fpe" % "sbt-jgiven-scalatest-reporter" % "0.1-SNAPSHOT")
```

If any issue please let me know. 

PS: thanks for your plugin, great to get nice JGiven reports with scalatest.